### PR TITLE
Created scaffold for await response in FAPI command handler [ESTTS-165]

### DIFF
--- a/src/fapi/command_handler/fapi_command_handler.cpp
+++ b/src/fapi/command_handler/fapi_command_handler.cpp
@@ -82,7 +82,20 @@ estts::Status fapi_command_handler::send_command(const std::vector<estts::comman
     return estts::ES_OK;
 }
 
+/**
+ * @brief Waits for a response from the satellite after command has been sent. This function waits the number of seconds
+ * specified by ESTTS_AWAIT_RESPONSE_PERIOD_SEC.
+ * @return ES_OK if response was received, or ES_UNSUCCESSFUL if timeout elapses.
+ */
 estts::Status fapi_command_handler::await_response() {
+    using namespace std::this_thread; // sleep_for, sleep_until
+    using namespace std::chrono; // nanoseconds, system_clock, seconds
+    int seconds_elapsed;
+    spdlog::info("Waiting for a response from EagleSat II");
+    for (seconds_elapsed = 0; seconds_elapsed < estts::ESTTS_AWAIT_RESPONSE_PERIOD_SEC; seconds_elapsed++) {
+        // TODO poll a serial interface or mailbox
+        sleep_until(system_clock::now() + seconds(1));
+    }
     return estts::ES_OK;
 }
 

--- a/src/utils/constants.h
+++ b/src/utils/constants.h
@@ -9,6 +9,7 @@
 namespace estts {
     const int ESTTS_MAX_RETRIES = 2;
     const int ESTTS_RETRY_WAIT_SEC = 1;
+    const int ESTTS_AWAIT_RESPONSE_PERIOD_SEC = 10;
     /* AX.25 Related constants */
     namespace ax25 {
         const char AX25_FLAG[] = "7E"; // Flag is constant


### PR DESCRIPTION
Created function called ```await_response``` called by the ```send_command``` function under the ```fapi_commandhandler``` class. The wait duration is configured with the ```ESTTS_AWAIT_RESPONSE_PERIOD_SEC``` variable in ```constants.h```.