### PR TITLE
Changed transmission interface class constructor to take no argument …

### DIFF
--- a/examples/estts-fapicommandhandler-test/src/main.cpp
+++ b/examples/estts-fapicommandhandler-test/src/main.cpp
@@ -7,7 +7,7 @@
 
 int main() {
     spdlog::set_level(spdlog::level::trace);
-    auto ti = new transmission_interface("127.0.0.1");
+    auto ti = new transmission_interface();
     auto eps_test = new eps_command(ti);
     eps_test->get_vitals();
     delete ti;

--- a/examples/estts-fapicommandscheduler-test/src/main.cpp
+++ b/examples/estts-fapicommandscheduler-test/src/main.cpp
@@ -16,7 +16,7 @@ int main() {
 
     auto schedule = new command_scheduler();
 
-    auto ti = new transmission_interface("127.0.0.1");
+    auto ti = new transmission_interface();
     auto eps = new eps_command(ti);
 
     // Bind eps object to method using lambda

--- a/src/ti/transmission_interface.cpp
+++ b/src/ti/transmission_interface.cpp
@@ -7,11 +7,11 @@
 
 #include "transmission_interface.h"
 
-transmission_interface::transmission_interface(const char *address) : ti_socket_handler(address,
+transmission_interface::transmission_interface() : ti_socket_handler(estts::ti_socket::TI_SOCKET_ADDRESS,
                                                                                         estts::ti_socket::TI_SOCKET_PORT),
-                                                                      ti_esttc(address,
+                                                                      ti_esttc(estts::ti_serial::TI_SERIAL_ADDRESS,
                                                                                estts::endurosat::ES_BAUD),
-                                                                      ti_serial_handler(address,
+                                                                      ti_serial_handler(estts::ti_serial::TI_SERIAL_ADDRESS,
                                                                                         estts::endurosat::ES_BAUD) {
     mtx.lock();
     if (initialize_ti() != estts::ES_OK) {

--- a/src/ti/transmission_interface.h
+++ b/src/ti/transmission_interface.h
@@ -18,7 +18,7 @@ private:
     estts::Status check_ti_health();
 
 public:
-    explicit transmission_interface(const char *address);
+    explicit transmission_interface();
 
     ~transmission_interface();
 

--- a/src/utils/constants.h
+++ b/src/utils/constants.h
@@ -96,12 +96,17 @@ namespace estts {
             const char *COMMAND_SCW = "00";
         };
     }
+
+    namespace ti_serial {
+        const char TI_SERIAL_ADDRESS[] = "/dev/cu.";
+    }
     
     namespace ti_socket {
         const int MAX_RETRIES = 2;
         const int WAIT_TIME_SEC = 2;
-        const int TI_SOCKET_PORT = 8080;
         const int TI_SOCKET_BUF_SZ = 1024;
+        const char TI_SOCKET_ADDRESS[] = "127.0.0.1";
+        const int TI_SOCKET_PORT = 8080;
     }
 
     typedef struct estts_command {


### PR DESCRIPTION
Created constants in ```constants.h``` to create scoped variables representing socket address and serial address. This change was made so that in the future, the transmission interface can be used as a lower level interface as opposed to initialized before a command is passed [ESTTS-172]

[ESTTS-172]: https://eaglesat2.atlassian.net/browse/ESTTS-172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ